### PR TITLE
Fix bintray publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import bintray.Keys._
-
 git.baseVersion   := "1.0.0"
 
 versionWithGit
@@ -18,15 +16,13 @@ sbtPlugin         := true
 
 publishMavenStyle := false
 
-bintrayPublishSettings
-
 resolvers         += Classpaths.sbtPluginReleases
 
 licenses          := Seq("BSD" -> url("http://opensource.org/licenses/BSD"))
 
-repository in bintray          := "sbt-plugins"
+bintrayRepository := "sbt-plugins"
 
-bintrayOrganization in bintray := None
+bintrayOrganization := None
 
 // this plugin depends on the sbt-osgi plugin -- 2-for-1!
 // TODO update to 0.8.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
 
 // incompatible with sbt-gpg (https://github.com/softprops/bintray-sbt/pull/10)
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.1")
+// JZ: is this still true after updating to 0.3.0?
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
The previous commit that upgraded SBT led to a binary incompat
with a JSON library during bintray publishing. I only noticed
this after tagging v1.0.4, so I made these changes manually
on top of the tag to publish the release.

Review by @adriaanm 