### PR TITLE
Introduce new scalaVersionsByJvm setting

### DIFF
--- a/src/main/scala/ScalaModulePlugin.scala
+++ b/src/main/scala/ScalaModulePlugin.scala
@@ -72,17 +72,17 @@ object ScalaModulePlugin extends Plugin {
     pomIncludeRepository := { _ => false },
     pomExtra := (
       <issueManagement>
-        <system>JIRA</system>
-        <url>https://issues.scala-lang.org/</url>
+        <system>GitHub</system>
+        <url>https://github.com/scala/{repoName.value}/issues</url>
       </issueManagement>
       <developers>
         <developer>
-          <id>epfl</id>
-          <name>EPFL</name>
+          <id>lamp</id>
+          <name>LAMP/EPFL</name>
         </developer>
         <developer>
-          <id>Typesafe</id>
-          <name>Typesafe, Inc.</name>
+          <id>Lightbend</id>
+          <name>Lightbend, Inc.</name>
         </developer>
       </developers>
     )

--- a/src/main/scala/ScalaModulePlugin.scala
+++ b/src/main/scala/ScalaModulePlugin.scala
@@ -20,11 +20,6 @@ object ScalaModulePlugin extends Plugin {
     // so we don't have to wait for sonatype to synch to maven central when deploying a new module
     resolvers += Resolver.sonatypeRepo("releases"),
 
-    // to allow compiling against snapshot versions of Scala
-    resolvers += Resolver.sonatypeRepo("snapshots"),
-
-    // resolvers += "scala-release-temp" at "http://private-repo.typesafe.com/typesafe/scala-release-temp/"
-
     // don't use for doc scope, scaladoc warnings are not to be reckoned with
     // TODO: turn on for nightlies, but don't enable for PR validation... "-Xfatal-warnings"
     scalacOptions in compile ++= Seq("-optimize", "-feature", "-deprecation", "-unchecked", "-Xlint"),


### PR DESCRIPTION
Make it easier for modules to use multiple Scala versions depending on the JVM version. Example config in a module:

```
// Map[JvmVersion, List[(ScalaVersion, UseForPublishing)]]
scalaVersionsByJvm := {
  val v211 = "2.11.8"
  val v212 = "2.12.2"

  Map(
    6 -> List(v211 -> true),
    7 -> List(v211 -> false),
    8 -> List(v212 -> true, v211 -> false),
    9 -> List(v212 -> false, v211 -> false)
  )
}
```

This will set `crossScalaVersions` according to the JVM version. If the `TRAVIS_TAG` environment variable is defined and we're publishing a release, the selection of Scala versions is filtered accordingly.