### PR TITLE
Convert to AutoPlugin, apply Scala version settings to the build

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
Make sure to set `crossScalaVersions` / `scalaVersion` (using `scalaVersionsByJvm`) in the
build, not only the project where `scalaModuleSettings` is referenced.