### PR TITLE
Import from renamed sbt-osgi package

### DIFF
--- a/src/main/scala/ScalaModulePlugin.scala
+++ b/src/main/scala/ScalaModulePlugin.scala
@@ -1,6 +1,6 @@
 package com.lightbend.tools.scalamoduleplugin
 
-import com.typesafe.sbt.osgi.{OsgiKeys, SbtOsgi}
+import com.github.sbt.osgi.{OsgiKeys, SbtOsgi}
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{HeaderLicense, headerLicense}
 import sbt.Keys._
 import sbt.{Def, _}


### PR DESCRIPTION
Follows https://github.com/sbt/sbt-osgi/pull/127. This resolves four deprecation warnings.